### PR TITLE
allow loader to show when one is passed in and defined BUGFIX

### DIFF
--- a/imports/plugins/core/revisions/client/containers/publishContainer.js
+++ b/imports/plugins/core/revisions/client/containers/publishContainer.js
@@ -34,11 +34,7 @@ class PublishContainer extends Component {
             this.props.onPublishSuccess(result);
           }
         } else {
-          const message = i18next.t("revisions.noChangesPublished", {
-            defaultValue: "There are no changes to publish"
-          });
-
-          Alerts.toast(message, "warning");
+          Alerts.toast(error.message, "error");
         }
       });
     }

--- a/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/childVariant.js
+++ b/imports/plugins/included/product-variant/client/templates/products/productDetail/variants/variantForm/childVariant.js
@@ -111,7 +111,7 @@ Template.childVariantForm.events({
     Meteor.call("products/updateProductField", variant._id, field, value,
       error => {
         if (error) {
-          throw new Meteor.Error("error updating variant", error);
+          Alerts.toast(error.message, "error");
         }
       });
     return ReactionProduct.setCurrentVariant(variant._id);

--- a/lib/api/compose.js
+++ b/lib/api/compose.js
@@ -38,7 +38,7 @@ function getTrackerLoader(reactiveMapper) {
 export function composeWithTracker(reactiveMapper, LoadingComponent) {
   const options = {};
 
-  if (typeof LoadingComponent === "undefined") {
+  if (typeof LoadingComponent !== "undefined") {
     options.loadingHandler = () => { // eslint-disable-line react/display-name
       return (
         <LoadingComponent />


### PR DESCRIPTION
No custom `LoadingComponent` would appear when passed to `composeWithTracker` due to reversed logic statement. Wasn't able to find an issue related to this.

_Currently on releases/development on an individual product page:_ 
- No custom loading component appears when passed to `composeWithTracker` (as render is never reached.)

_With this PR on an individual product page:_
- A custom loading component that was passed to `composeWithTracker` should appear before the product fully loads.
